### PR TITLE
feat: add uncompressed size calculation for image layers

### DIFF
--- a/pkg/service/image_layers.go
+++ b/pkg/service/image_layers.go
@@ -12,9 +12,10 @@ import (
 
 // LayerMetadata stores layer metadata information
 type LayerMetadata struct {
-	Digest string `json:"digest"`
-	Path   string `json:"path"`
-	Size   int64  `json:"size"`
+	Digest           string `json:"digest"`
+	Path             string `json:"path"`
+	Size             int64  `json:"size"`
+	UncompressedSize int64  `json:"uncompressed_size"`
 }
 
 // LayerCache manages image layer caching


### PR DESCRIPTION
Add functionality to calculate actual uncompressed size of image layers:
- Calculate uncompressed size by reading tar headers
- Store both compressed and uncompressed sizes in metadata
- Use uncompressed size for total image size reporting
- Handle gzip decompression properly